### PR TITLE
🐛 fix(UnstuckDialog): correct typo in error messages for Unstuck command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
-version=2.2.0-SNAPSHOT
+version=2.2.1-SNAPSHOT

--- a/surf-unstuck-paper/src/main/kotlin/dev/slne/surf/unstuck/paper/dialogs/UnstuckDialog.kt
+++ b/surf-unstuck-paper/src/main/kotlin/dev/slne/surf/unstuck/paper/dialogs/UnstuckDialog.kt
@@ -42,9 +42,9 @@ fun createUnstuckDialog() = dialog {
                 info("Bitte beachte folgende Informationen:")
                 appendNewline()
 
-                error("Der Befehl darf nur verwendet werden, wenn du auch tatsächlich feststeckst")
+                error("Der Befehl darf nur verwendet werden, wenn du auch tatsächlich feststeckst.")
                 appendSpace()
-                error("Der Missbrauch des Befehls wird als Exploiting gewertet und dementsprechend geahndet")
+                error("Der Missbrauch des Befehls wird als Exploiting gewertet und dementsprechend geahndet.")
                 appendNewline(2)
 
                 info("Möchtest du dich wirklich zum Spawn teleportieren lassen?")


### PR DESCRIPTION
- add missing period at the end of error messages